### PR TITLE
Restore Windows build-ability 

### DIFF
--- a/syngen/defopcode.c
+++ b/syngen/defopcode.c
@@ -268,7 +268,7 @@ done_generating_code ()
 void
 generate_opcode (ParsedOpcodeInfo *info, SymbolTable *sym)
 {
-#if	!defined(__GNUC__)
+#if	!defined(__GNUC__) && !defined(WIN32)
   extern void *alloca(int);
 #endif
   OperandInfo *operand_info;

--- a/syngen/parse.c
+++ b/syngen/parse.c
@@ -18,6 +18,8 @@
 #include <errno.h>
 #ifndef WIN32
 #include <unistd.h>
+#else
+#include <io.h>
 #endif
 
 static List *parse_expression (void);


### PR DESCRIPTION
This restores the ability to build for MS Windows.  It was done as part of a [re]port of Executor 2000 to Windows, which has a separate PR at https://github.com/autc04/executor/pull/17 